### PR TITLE
Narrow and Clarify Label Conditions for Matching in Evaluation

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -111,8 +111,8 @@ def pq_compute_single_core(proc_id, annotation_set, gt_folder, pred_folder, cate
         gt_pred_map = {}
         labels, labels_cnt = np.unique(pan_gt_pred, return_counts=True)
         for label, intersection in zip(labels, labels_cnt):
-            gt_id = label // OFFSET
-            pred_id = label % OFFSET
+            gt_id = (label // OFFSET).astype(np.uint64)
+            pred_id = (label % OFFSET).astype(np.uint64)
             gt_pred_map[(gt_id, pred_id)] = intersection
 
         # count all matched pairs
@@ -120,9 +120,9 @@ def pq_compute_single_core(proc_id, annotation_set, gt_folder, pred_folder, cate
         pred_matched = set()
         for label_tuple, intersection in gt_pred_map.items():
             gt_label, pred_label = label_tuple
-            if gt_label not in gt_segms:
+            if gt_label == VOID:
                 continue
-            if pred_label not in pred_segms:
+            if pred_label == VOID:
                 continue
             if gt_segms[gt_label]['iscrowd'] == 1:
                 continue


### PR DESCRIPTION
The sanity checks cover other missing prediction label conditions, and the ground truth can be assumed consistent (famous last words) across the json and png, so the only necessary checks are for skipping void.

I don't know why the IDs are turning into float types, but I'm casting them back since they're integral elsewhere like in the data format.