### PR TITLE
fix: json dump type error

### DIFF
--- a/converters/detection2panoptic_coco_format.py
+++ b/converters/detection2panoptic_coco_format.py
@@ -47,7 +47,7 @@ def convert_detection_to_panoptic_coco_format_single_core(
         anns = coco_detection.loadAnns(anns_ids)
 
         panoptic_record = {}
-        panoptic_record['image_id'] = img_id
+        panoptic_record['image_id'] = int(img_id)
         file_name = '{}.png'.format(img['file_name'].rsplit('.')[0])
         panoptic_record['file_name'] = file_name
         segments_info = []


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/zeyuzeng/Software/pycharm-community-2019.2.3/helpers/pydev/pydevd.py", line 2073, in <module>
    main()
  File "/home/zeyuzeng/Software/pycharm-community-2019.2.3/helpers/pydev/pydevd.py", line 2067, in main
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/home/zeyuzeng/Software/pycharm-community-2019.2.3/helpers/pydev/pydevd.py", line 1418, in run
    return self._exec(is_module, entry_point_fn, module_name, file, globals, locals)
  File "/home/zeyuzeng/Software/pycharm-community-2019.2.3/helpers/pydev/pydevd.py", line 1425, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/home/zeyuzeng/Software/pycharm-community-2019.2.3/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/zeyuzeng/Projects/py_project/autox_anno_eval/main.py", line 96, in <module>
    main()
  File "/home/zeyuzeng/Projects/py_project/autox_anno_eval/main.py", line 85, in main
    '/home/zeyuzeng/Downloads/testin_annotation/annotation/match_categories.json')
  File "/home/zeyuzeng/Projects/py_project/autox_anno_eval/converters/detection2panoptic_coco_format.py", line 131, in convert_detection_to_panoptic_coco_format
    save_json(d_coco, output_json_file)
  File "/home/zeyuzeng/anaconda3/lib/python3.7/site-packages/panopticapi/utils.py", line 99, in save_json
    json.dump(d, f)
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/home/zeyuzeng/anaconda3/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type int64 is not JSON serializable
```