### PR TITLE
Fix TypeError in JSON serialization in 2channels2panoptic_coco_format for PY3

### DIFF
--- a/converters/2channels2panoptic_coco_format.py
+++ b/converters/2channels2panoptic_coco_format.py
@@ -64,7 +64,7 @@ def convert_single_core(proc_id, image_set, categories, source_folder, segmentat
             segment_id, color = id_generator.get_id_and_color(sem)
             pan_format[mask] = color
             segm_info.append({"id": segment_id,
-                              "category_id": sem})
+                              "category_id": sem.item()})
 
         annotations.append({'image_id': image_info['id'],
                             'file_name': file_name,

--- a/converters/2channels2panoptic_coco_format.py
+++ b/converters/2channels2panoptic_coco_format.py
@@ -64,7 +64,7 @@ def convert_single_core(proc_id, image_set, categories, source_folder, segmentat
             segment_id, color = id_generator.get_id_and_color(sem)
             pan_format[mask] = color
             segm_info.append({"id": segment_id,
-                              "category_id": sem.item()})
+                              "category_id": int(sem)})
 
         annotations.append({'image_id': image_info['id'],
                             'file_name': file_name,


### PR DESCRIPTION
Currently, 2channels2panoptic_coco_format.py can break with the following error for when calling save_json with PY3:

TypeError: Object of type int64 is not JSON serializable

To reproduce the errors, run the provided sample commands with PY3:

python3 converters/2channels2panoptic_coco_format.py \
  --source_folder sample_data/panoptic_examples_2ch_format \
  --images_json_file sample_data/images_info_examples.json \
  --predictions_json_file converted_data/panoptic_coco_from_2ch.json

The issue can be caused by different behavior of the following lines:
isinstance(np.int64(4), int) returns True in PY2 but False in PY3, which was also found in https://mail.python.org/pipermail/numpy-discussion/2015-June/073031.html

isinstance is used in python's JSON serialization to identify types:
https://github.com/python/cpython/blob/main/Lib/json/encoder.py#L309
so in PY3 it will no longer directly serialize numpy scalars.

A solution to fix is to add a '.item()' to explicitly convert the numpy into int, which works for PY3.