### PR TITLE
Conversion from panoptic to segmentic segmentation with color. 

### DIFF
--- a/converters/panoptic2semantic_segmentation.py
+++ b/converters/panoptic2semantic_segmentation.py
@@ -51,6 +51,7 @@ def extract_semantic_single_core(proc_id,
                                  categories,
                                  save_as_png,
                                  save_with_color,
+                                 cat_id_colormap,
                                  things_other):
     annotation_semantic_seg = []
     for working_idx, annotation in enumerate(annotations_set):
@@ -114,6 +115,7 @@ def extract_semantic(input_json_file,
                      semantic_seg_folder,
                      categories_json_file,
                      save_with_color,
+                     cat_id_colormap,
                      things_other):
     start_time = time.time()
     with open(input_json_file, 'r') as f:
@@ -168,7 +170,8 @@ def extract_semantic(input_json_file,
         p = workers.apply_async(extract_semantic_single_core,
                                 (proc_id, annotations_set, segmentations_folder,
                                  output_json_file, semantic_seg_folder,
-                                 categories, save_as_png, save_with_color, things_other))
+                                 categories, save_as_png, 
+                                 save_with_color, cat_id_colormap, things_other))
         processes.append(p)
     annotations_coco_semantic_seg = []
     for p in processes:
@@ -237,4 +240,5 @@ if __name__ == "__main__":
                      args.semantic_seg_folder,
                      args.categories_json_file,
                      args.save_with_color,
+                     cat_id_colormap,
                      args.things_other)

--- a/converters/panoptic2semantic_segmentation.py
+++ b/converters/panoptic2semantic_segmentation.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 import PIL.Image as Image
 
-from panopticapi.utils import get_traceback, rgb2id, save_json
+from panopticapi.utils import get_traceback, rgb2id, cat_id2rgb, save_json
 
 try:
     # set up path for pycocotools
@@ -40,6 +40,7 @@ def extract_semantic_single_core(proc_id,
                                  semantic_seg_folder,
                                  categories,
                                  save_as_png,
+                                 save_with_color,
                                  things_other):
     annotation_semantic_seg = []
     for working_idx, annotation in enumerate(annotations_set):
@@ -57,7 +58,9 @@ def extract_semantic_single_core(proc_id,
 
         pan = rgb2id(pan_format)
         semantic = np.zeros(pan.shape, dtype=np.uint8)
-
+        if save_with_color:
+            rgb_seg_shape = list(pan.shape) ; rgb_seg_shape.append(3)
+            semantic = np.zeros(rgb_seg_shape, dtype=np.uint8)
         RLE_per_category = defaultdict(list)
         for segm_info in annotation['segments_info']:
             cat_id = segm_info['category_id']
@@ -65,7 +68,10 @@ def extract_semantic_single_core(proc_id,
                 cat_id = OTHER_CLASS_ID
             mask = pan == segm_info['id']
             if save_as_png:
-                semantic[mask] = cat_id
+                if save_with_color:
+                    semantic[mask] = cat_id_colormap[str(cat_id)]
+                else:
+                    semantic[mask] = cat_id
             else:
                 RLE = COCOmask.encode(np.asfortranarray(mask.astype('uint8')))
                 RLE['counts'] = RLE['counts'].decode('utf8')
@@ -97,6 +103,7 @@ def extract_semantic(input_json_file,
                      output_json_file,
                      semantic_seg_folder,
                      categories_json_file,
+                     save_with_color,
                      things_other):
     start_time = time.time()
     with open(input_json_file, 'r') as f:
@@ -123,7 +130,10 @@ def extract_semantic(input_json_file,
                             options must be used specified")
         else:
             save_as_png = True
-            print("in PNG format:")
+            if save_with_color:
+                print("in PNG format with color:")
+            else:
+                print("in PNG format:")
             print("\tFolder with semnatic segmentations: {}".format(semantic_seg_folder))
             if not os.path.isdir(semantic_seg_folder):
                 print("Creating folder {} for semantic segmentation PNGs".format(semantic_seg_folder))
@@ -148,7 +158,7 @@ def extract_semantic(input_json_file,
         p = workers.apply_async(extract_semantic_single_core,
                                 (proc_id, annotations_set, segmentations_folder,
                                  output_json_file, semantic_seg_folder,
-                                 categories, save_as_png, things_other))
+                                 categories, save_as_png, save_with_color, things_other))
         processes.append(p)
     annotations_coco_semantic_seg = []
     for p in processes:
@@ -201,13 +211,20 @@ if __name__ == "__main__":
     parser.add_argument('--categories_json_file', type=str,
                         help="JSON file with Panoptic COCO categories information",
                         default='./panoptic_coco_categories.json')
+    parser.add_argument('--save_with_color', type=bool,
+                        help="If '--segmantic_seg_folder' is specificed, \
+                        resulting semantic segmentation PNGs will be rbg, \
+                        based on the cateogory colormap in '--categories_json_file'",
+                        default=False)                    
     parser.add_argument('--things_other', action='store_true',
                         help="Is set, all things classes are merged into one \
                         'other' class")
     args = parser.parse_args()
+    cat_id_colormap = cat_id2rgb(args.categories_json_file)
     extract_semantic(args.input_json_file,
                      args.segmentations_folder,
                      args.output_json_file,
                      args.semantic_seg_folder,
                      args.categories_json_file,
+                     args.save_with_color,
                      args.things_other)

--- a/converters/panoptic2semantic_segmentation.py
+++ b/converters/panoptic2semantic_segmentation.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 import PIL.Image as Image
 
-from panopticapi.utils import get_traceback, rgb2id, cat_id2rgb, save_json
+from panopticapi.utils import get_traceback, rgb2id, save_json
 
 try:
     # set up path for pycocotools
@@ -31,6 +31,16 @@ except Exception:
     raise Exception("Please install pycocotools module from https://github.com/cocodataset/cocoapi")
 
 OTHER_CLASS_ID = 183
+
+
+def cat_id2rgb(categories_json_file):
+    info = json.load(open(categories_json_file, "r"))
+    cat_id_colormap = {}
+    for cat in info:
+        if str(cat['id']) not in cat_id_colormap.keys():
+            cat_id_colormap[str(cat['id'])] = list(cat['color'])
+    return cat_id_colormap
+
 
 @get_traceback
 def extract_semantic_single_core(proc_id,

--- a/panopticapi/utils.py
+++ b/panopticapi/utils.py
@@ -94,6 +94,15 @@ def id2rgb(id_map):
     return color
 
 
+def cat_id2rgb(cat_id_map, categories_json_file):
+    info = json.load(open(categories_json_file, "r"))
+    cat_id_colormap = {}
+    for cat in info:
+        if str(cat['id']) not in cat_id_colormap.keys():
+            cat_id_colormap[str(cat['id'])] = list(cat['color'])
+    return cat_id_colormap
+
+
 def save_json(d, file):
     with open(file, 'w') as f:
         json.dump(d, f)

--- a/panopticapi/utils.py
+++ b/panopticapi/utils.py
@@ -94,15 +94,6 @@ def id2rgb(id_map):
     return color
 
 
-def cat_id2rgb(categories_json_file):
-    info = json.load(open(categories_json_file, "r"))
-    cat_id_colormap = {}
-    for cat in info:
-        if str(cat['id']) not in cat_id_colormap.keys():
-            cat_id_colormap[str(cat['id'])] = list(cat['color'])
-    return cat_id_colormap
-
-
 def save_json(d, file):
     with open(file, 'w') as f:
         json.dump(d, f)

--- a/panopticapi/utils.py
+++ b/panopticapi/utils.py
@@ -94,7 +94,7 @@ def id2rgb(id_map):
     return color
 
 
-def cat_id2rgb(cat_id_map, categories_json_file):
+def cat_id2rgb(categories_json_file):
     info = json.load(open(categories_json_file, "r"))
     cat_id_colormap = {}
     for cat in info:


### PR DESCRIPTION
This allows users of the panopticapi to convert from panoptic to segmentatic segmentation with rgb-colored pngs. The color mapping is based off the 'panoptic_coco_categories.json' category color mapping. To convert with color, add the argument '--save_with_color True'. This only adds color if the user is saving to pngs.