### PR TITLE
Fix TypeError in JSON serialization

### DIFF
--- a/converters/detection2panoptic_coco_format.py
+++ b/converters/detection2panoptic_coco_format.py
@@ -47,7 +47,7 @@ def convert_detection_to_panoptic_coco_format_single_core(
         anns = coco_detection.loadAnns(anns_ids)
 
         panoptic_record = {}
-        panoptic_record['image_id'] = img_id
+        panoptic_record['image_id'] = int(img_id)
         file_name = '{}.png'.format(img['file_name'].rsplit('.')[0])
         panoptic_record['file_name'] = file_name
         segments_info = []


### PR DESCRIPTION
output json not realizable due to image_id was kept as numpy dtype. converted to int.